### PR TITLE
Avoid writing partial functions

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -12,6 +12,7 @@ Try to write code that is easy to understand, debug, and modify.
 
 - [Formatting](#formatting)
 - [Prefer `let` over `where`](#prefer-let-over-where)
+- [Avoid writing partial functions](#avoid-writing-partial-functions)
 
 ## Formatting
 
@@ -41,3 +42,21 @@ let kibi = 2 ^ 10 in 3 * kibi
 ```
 
 https://stackoverflow.com/questions/4362328/haskell-where-vs-let
+
+## Avoid writing partial functions
+
+Partial functions are difficult to work with because they can fail but their type signatures don't express that.
+Avoid non-exhaustive pattern matching, `undefined`, and `error`.
+Instead prefer types like `Maybe result` or `Either failure success`.
+
+``` hs
+-- bad
+first (x : _) = x
+
+-- good
+first xs = case xs of
+  x : _ -> Just x
+  _ -> Nothing
+```
+
+https://www.parsonsmatt.org/2017/10/11/type_safety_back_and_forth.html


### PR DESCRIPTION
I had a hard time finding a good resource talking about the downsides of partial functions and what to use instead. Matt Parson's post isn't exactly about partial functions, but it does outline many ways to encode invariants in the type system. 