### PR TITLE
Add some notes about compiler/linter errors

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -107,3 +107,14 @@ if canAccess thing user
 ```
 
 https://np.reddit.com/r/haskell/comments/5bkqf1/exceptions_best_practices_in_haskell/
+
+## Warnings and hints
+
+### Compiler warnings cannot be merged to master
+
+NB: We use -Wall (-Weverything starting in ghc 8.4.1) and -Werror in package.yaml files to catch as many potential mistakes as possible.
+One of the great things about Haskell is the static analysis provided by the compiler/type system. With that, and [select is not broken](https://blog.codinghorror.com/the-first-rule-of-programming-its-always-your-fault/) i.e. the compiler is not at fault, code that violates these cannot be permitted to make it into the primary branch, most often `master`.
+
+### Hlint warnings should not be merged to master
+
+Linters allow us to keep a common baseline of style and enforce some of the above guidelines such as disallowing `head`. We use [hlint](https://github.com/ndmitchell/hlint) and things caught by it should not be merged into `master` for projects.


### PR DESCRIPTION
This is not intended to be merged as is, but to start the discussion around these things. In fact, it isn't clear that this is necessarily "style" at all so this may not be an appropriate place for these. On the other hand, it _might_ be useful to document this somewhere.

Some notes:
- The language around compiler errors (warnings too, but `-Werror`) is purposefully more strict than the lint errors. This is to convey that, especially in a "the world is on fire"  type situation, the linter errors are less important than compiler ones.
- Also mentioned, so it is hopefully remembered, when we can finally get to ghc >= 8.4.1 to change our `-Wall` to `-Weverything` since `all != everything` :/